### PR TITLE
Add job advert pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
                 <section class="page-title-section">
                     <div class="page-title">
                         <ol class="breadcrumb pull-right">
-                            <li><a href="https://gigasciencejournal.com/">Home</a></li>
+                            <!-- <li><a href="https://gigasciencejournal.com/">Home</a></li> -->
                             <li class="active">Jobs</li>
                         </ol>
                         <h1 style="font-size: medium;">Jobs at GigaScience</h1>

--- a/index.html
+++ b/index.html
@@ -47,9 +47,6 @@
                         <h1 style="font-size: medium;">Jobs at GigaScience</h1>
                     </div>
                 </section>
-                <div class="subsection">
-                    <img src="assets/about.png">
-                </div>
                 <section>
                     <h4 class="about-title">Currently open for applications:</h4>
                     

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
                     
                     <ul>
                         <li><a href="jobs/tech/senior_software_engineer.html">Senior Software Engineer (Senior Full-stack developer, remote, full-time, contract)</a></li>
-                        <li>Software Engineer (Full-stack developer, remote, full-time, contract)</li>
+                        <li><a href="jobs/tech/software_engineer.html">Software Engineer (Full-stack developer, remote, full-time, contract)</a></li>
                     </ul>
                     <hr>
                     <h4 class="about-title">Other positions</h4>

--- a/jobs/tech/senior_software_engineer.html
+++ b/jobs/tech/senior_software_engineer.html
@@ -20,7 +20,7 @@
                     <!-- <link rel="stylesheet" type="text/css" href="/css/common.css" /> -->
                     <!-- Using current.css for developing fix for CSS problems in current green layout -->
                     <link rel="stylesheet" type="text/css" href="../../assets/current.css">
-                    <title>Jobs at GigaScience</title>
+                    <title>Jobs at GigaScience: Senior Software Engineer (Senior Full-Stack Developer)</title>
     </head>
     <body>
         <div class="base-nav-bar">
@@ -45,7 +45,7 @@
                             <li><a href="../../index.html">Jobs</a></li>
                             <li class="active">Senior Software Engineer</li>
                         </ol>
-                        <h1 style="font-size: medium;">Jobs at GigaScience: Senior Software Engineer (Senior Full-Stack Developer)</h1>
+                        <h1 style="font-size: medium;">Jobs at GigaScience</h1>
                     </div>
                 </section>
                 <section>
@@ -138,6 +138,7 @@ GitHub’s Pull Requests are our main mechanism for code contribution and code r
                     <h4>How to apply:</h4>
                     <dl>
                         <dt>By email:</dt>
+                        <dd>Specify which role you are applying in the subject field</dd>
                         <dd>Send resume and a cover letter to tech AT gigasciencejournal.com</dd>
                     </dl>
                 </section>

--- a/jobs/tech/senior_software_engineer.html
+++ b/jobs/tech/senior_software_engineer.html
@@ -41,7 +41,7 @@
                 <section class="page-title-section">
                     <div class="page-title">
                         <ol class="breadcrumb pull-right">
-                            <li><a href="https://gigasciencejournal.com/">Home</a></li>
+                            <!-- <li><a href="https://gigasciencejournal.com/">Home</a></li> -->
                             <li><a href="../../index.html">Jobs</a></li>
                             <li class="active">Senior Software Engineer</li>
                         </ol>

--- a/jobs/tech/software_engineer.html
+++ b/jobs/tech/software_engineer.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <meta name="language" content="en">
+        <meta name="robots" content="noindex, nofollow">
+        <meta name="googlebot" content="noindex, nofollow">
+        <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
+        <!--[if lt IE 9]>
+                <script src="http://html5shim.googlecode.com/svn/trunk/html5.js">
+                </script>
+            <![endif]-->
+                    <link rel="stylesheet" type="text/css" href="../../assets/jquery-ui.css">
+                    <link rel="stylesheet" type="text/css" href="../../assets/bootstrap.min.css">
+                    <link rel="stylesheet" type="text/css" href="../../assets/font-awesome.min.css">
+                    <link rel="stylesheet" type="text/css" href="../../assets/open_sans.css">
+                    <link rel="stylesheet" type="text/css" href="../../assets/pt_sans.css">
+                    <link rel="stylesheet" type="text/css" href="../../assets/lato.css">
+                    <!-- Disable common.css whilst fixing CSS problems -->
+                    <!-- <link rel="stylesheet" type="text/css" href="/css/common.css" /> -->
+                    <!-- Using current.css for developing fix for CSS problems in current green layout -->
+                    <link rel="stylesheet" type="text/css" href="../../assets/current.css">
+                    <title>Jobs at GigaScience: Software Engineer (Full-Stack Developer</title>
+    </head>
+    <body>
+        <div class="base-nav-bar">
+            <div class="container">
+                <div class="row">
+                    <div class="col-xs-4">
+                        <a href="https://gigasciencejournal.com/"><img id="logo-GigaScience" class="journal-logo" src="../../assets/gigascience_title310871745.svg" alt="GigaScience" height="70em" style="margin-top:0.5em;"></a>
+                    </div>
+                    <div class="col-xs-4 col-xs-offset-4">
+                    </div>
+                </div>
+            </div>
+        </div>
+        
+        <div class="clear"></div>
+        <div class="content">
+            <div class="container">
+                <section class="page-title-section">
+                    <div class="page-title">
+                        <ol class="breadcrumb pull-right">
+                            <li><a href="https://gigasciencejournal.com/">Home</a></li>
+                            <li><a href="../../index.html">Jobs</a></li>
+                            <li class="active">Software Engineer</li>
+                        </ol>
+                        <h1 style="font-size: medium;">Jobs at GigaScience</h1>
+                    </div>
+                </section>
+                <section>
+                    <h1>Role: Software Engineer (Full-Stack Developer)</h1>
+
+<p>Location:  Remote<br/>
+Start date: 2023<br/>
+Salary: HK$25K - 35K per month</p>
+
+<h2>Who we are</h2>
+
+<p>We are GigaScience Press. Based in Hong Kong, but our teams are working remotely from all over the world.<br/>
+We publish open-science journals, like the prestigious GigaScience Journal and the newer GigaByte, in the fields of Biology and Bioinformatics.<br/>
+Since we care about the reproducibility of scientific research, we have developed GigaDB, a system for storing research data reported in our published papers, which is freely- available for all to access and reproduce. <br/>
+GigaDB has historically been our core application and is managed as an open-source project.</p>
+
+<h2>Your role in the team</h2>
+
+<ul>
+<li>You will be joining a small team of software developers of diverse background and experience level.</li>
+<li>You will be configuring and coding functionalities on both legacy codebase and new codebase for the IT systems used by other teams in our organisation, and for those built for the scientist readers of our online journals.</li>
+<li>You will be contributing to the technical team’s effort in delivering and operating software for the rest of the organisation</li>
+</ul>
+
+
+<h2>Our technical stack</h2>
+
+<p>Backend: PHP 7/8, Yii, Codeception, PostgreSQL<br/>
+Frontend: Bootstrap, Vue.js, Jasmine, WebDriver<br/>
+Other: GitLab, Terraform, Ansible, Linux, Docker</p>
+
+<h2>Your responsibilities</h2>
+
+<ul>
+<li>Deliver quality software for our backend systems according to high coding standards</li>
+<li>Maintain and steadily grow the coverage of multi-layered test harnesses</li>
+<li>Propose and implement technical solutions according to our organisation’s systems architecture</li>
+<li>Write code for functionalities and bug fixes that follow good practices and proven design patterns</li>
+<li>Ensure production systems are functioning optimally</li>
+<li>Work autonomously and collaborate with other developers</li>
+<li>Continuously seek to automate for efficiency and error avoidance</li>
+<li>Contribute to the maintenance and improvement of coding standards and their effectiveness</li>
+<li>Contribute to the setup, operation, migration and retirement of (multi) cloud-based applications and their data</li>
+<li>Cultivate an open-source mindset by contributing to upstream open-source dependencies when it make sense, and by ensuring our own open-source projects stay so in both spirit and to the letter</li>
+<li>Participate in code reviews</li>
+</ul>
+
+
+<h2>Our methods</h2>
+
+<p>We use SCRUM principles that we have adapted to our circumstances as the process that drives our development cycles.<br/>
+Both the product owners that represent the rest of the organisation and all members of the technical team participate in this process.<br/>
+GitHub is the central piece for managing product specifications and development artefacts, while GitLab is the backbone of our CI/CD process.<br/>
+GitHub’s Pull Requests are our main mechanism for code contribution and code reviews. The latter are also performed using other ad-hoc approaches when needed.</p>
+
+<h2>Your qualifications</h2>
+
+<ul>
+<li>2+ years of relevant work experience</li>
+<li>Excellent skills in programming with modern PHP, Web frameworks (e.g: Yii, Laravel, Symfony), Object Oriented Design, Web Technologies, Cloud Integration, Automated Testing, Database Design</li>
+<li>Knowledge of modern javascript on the frontend</li>
+<li>Experience with Agile or Scrum software development methodologies</li>
+<li>Ability to multitask, organise, prioritise work, assisting others and reflecting</li>
+</ul>
+
+
+<h2>What you will find working for us</h2>
+
+<ul>
+<li>An organisation made of culturally and language diverse group of enthusiastic and knowledgeable academics and developers</li>
+<li>Leadership that deeply cares for personal development</li>
+<li>A team that value curiosity, transparency, pragmatism, consistency, and helping each other</li>
+<li>A team that understand and aim to practise software quality through: BDD and TDD, appropriate use of design patterns, improving through deliberate practice, favouring of long proven technology and stability</li>
+<li>An organisation that while mostly remote, still collectively loves to reconnect in person and with peers of the industries (Life Sciences and Software Engineering) at conferences/special events whenever possible</li>
+</ul>
+
+
+
+
+                    <hr>
+                </section>
+                <section>
+                    <h4>How to apply:</h4>
+                    <dl>
+                        <dt>By email:</dt>
+                        <dd>Specify which role you are applying in the subject field</dd>
+                        <dd>Send resume and a cover letter to tech AT gigasciencejournal.com</dd>
+                    </dl>
+                </section>
+                    <table class="table text-center about-partner-table">
+                        <tbody>
+                        <tr>
+                            <td><a href="http://www.datacite.org/"><img src="../../assets/DataCite_header_final1_1.png"></a></td>
+                            <td><a href="http://isa-tools.org/"><img src="../../assets/isa.jpg"></a></td>
+                            <td><a href="https://fairsharing.org/"><img src="../../assets/fairshare.png"></a></td>
+                            <td><a href="http://wokinfo.com/products_tools/multidisciplinary/dci/"><img src="../../assets/data_citation.png"></a></td>
+                            <td><a href="http://re3data.org/"><img src="../../assets/re3data.png"></a></td>
+                            <td><a href="https://repositive.io/"><img src="../../assets/repositive.png"></a></td>
+                            <td><a href="https://datamed.org/"><img src="../../assets/datamed.png"></a></td>
+                        </tr>
+                        </tbody>
+                    </table>
+                    <p>This website’s content and logo has been published under the Creative Commons CC0 license</p>
+                </section>
+            </div>
+        </div>    
+        <div class="base-footer-bar">
+            <div class="container">
+                <div class="row">
+                    <div class="col-xs-6">
+                        <ul class="list-inline base-footer-logo-bar">
+                            <li><a href="http://gigasciencepress.com/"><img src="../../assets/gigascience_white.png" alt="Go to GigaScience Journal web site"></a></li>
+                            <li><a href="http://www.genomics.cn/"><img src="../../assets/bgi_logo_white.png" alt="Go to 华大基因 BGI (Beijing Genomics Institute) website"></a></li>
+                            <li><a href="https://www.cngb.org/"><img src="../../assets/chinagenbank.png" alt="Go to CNGB (China National Gene Bank) website"></a></li>
+                        </ul>
+                    </div>
+                    <div class="col-xs-6 text-right">
+                        <p class="base-footer-email"><a href="https://beta.gigadb.org/site/contact"><i class="fa fa-envelope"></i> database@gigasciencejournal.com</a></p>
+                        <ul class="list-inline base-footer-social-bar">
+                            <li>
+                                <a class="fa fa-facebook" style="text-decoration: none;" href="http://facebook.com/GigaScience" title="GigaScience on Facebook" aria-label="GigaScience on Facebook"></a>
+                            </li>
+                            <li>
+                                <a class="fa fa-twitter" style="text-decoration: none;" href="http://twitter.com/GigaScience" title="GigaScience on Twitter" aria-label="GigaScience on Twitter"></a>
+                            </li>
+                            <li>
+                                <a class="fa fa-weibo" style="text-decoration: none;" href="http://weibo.com/gigasciencejournal" title="Gigascience on Weibo" aria-label="GigaScience on Weibo"></a>
+                            </li>
+                            <li>
+                                <a class="fa fa-google-plus" style="text-decoration: none;" href="https://plus.google.com/u/0/104409890199786402308" title="GigaScience on Google+" aria-label="GigaScience on Google+"></a>
+                            </li>
+                            <li>
+                                <a class="fa fa-rss" style="text-decoration: none;" href="http://gigasciencejournal.com/blog/" title="Gigascience Blog" aria-label="GigaScience Blog"></a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+        
+    </body>
+</html>

--- a/jobs/tech/software_engineer.html
+++ b/jobs/tech/software_engineer.html
@@ -41,7 +41,7 @@
                 <section class="page-title-section">
                     <div class="page-title">
                         <ol class="breadcrumb pull-right">
-                            <li><a href="https://gigasciencejournal.com/">Home</a></li>
+                            <!-- <li><a href="https://gigasciencejournal.com/">Home</a></li> -->
                             <li><a href="../../index.html">Jobs</a></li>
                             <li class="active">Software Engineer</li>
                         </ol>


### PR DESCRIPTION
Implement as static HTML page under ``jobs/tech``:
 
* 2ab3c70 Feat: Add software engineer job advert
* 37f9ce1 Fix: Precise application method and tweak title of senior SE job advert

Can you check that the two job adverts are correct and can be navigated to before I share it with Laurie and others