### PR TITLE
fix: add more emphasis to freelance gigs and remove duplicate text

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,12 +75,7 @@
                     
                     We also welcome opensource contributions to our OpenData/OpenScience project, <a href="https://beta.gigadb.org">GigaDB</a>, 
                     as an alternative or additional way to engage with us.
-
-                    <hr>
-                    <h4 class="about-title">Freelance</h4>
-
-                    <a href="jobs/tech/freelance.html">This page</a> lists packaged work for freelancers.
-
+                    
                     <hr>
                 </section>
                 <section>

--- a/index.html
+++ b/index.html
@@ -53,6 +53,7 @@
                     <ul>
                         <li><a href="jobs/tech/senior_software_engineer.html">Senior Software Engineer (Senior Full-stack developer, remote, full-time, contract)</a></li>
                         <li><a href="jobs/tech/software_engineer.html">Software Engineer (Full-stack developer, remote, full-time, contract)</a></li>
+                        <li>Freelance Positions: See <a href="jobs/tech/freelance.html">this page</a> for a list of packaged work for contractors</li>
                     </ul>
                     <hr>
                     <h4 class="about-title">Other positions</h4>
@@ -73,12 +74,6 @@
                     <h4 class="about-title">Opensource contributions</h4>
                     
                     We also welcome opensource contributions to our OpenData/OpenScience project, <a href="https://beta.gigadb.org">GigaDB</a>, 
-                    as an alternative or additional way to engage with us.
-
-                    <hr>
-                    <h4 class="about-title">Opensource contributions</h4>
-
-                    We also welcome opensource contributions to our OpenData/OpenScience project, <a href="https://beta.gigadb.org">GigaDB</a>,
                     as an alternative or additional way to engage with us.
 
                     <hr>

--- a/jobs/tech/freelance.html
+++ b/jobs/tech/freelance.html
@@ -27,7 +27,7 @@
     <div class="container">
         <div class="row">
             <div class="col-xs-4">
-                <a href="https://gigasciencejournal.com/"><img id="logo-GigaScience" class="journal-logo" src="../../assets/gigascience_title310871745.svg" alt="GigaScience" height="70em" style="margin-top:0.5em;"></a>
+                <a href="https://gigasciencejournal.com/"><img id="logo-GigaScience" class="journal-logo" src="../../assets/GSPress-Color.v1.0.svg" alt="GigaScience" height="70em" style="margin-top:0.5em;"></a>
             </div>
             <div class="col-xs-4 col-xs-offset-4">
             </div>


### PR DESCRIPTION
Following feedback from Laurie, added more emphasis to freelance gigs.
While doing so, noticed the section on opensource contributions was duplicated.